### PR TITLE
Add .pro extension

### DIFF
--- a/Syntax/ChordPro.JSON-tmLanguage
+++ b/Syntax/ChordPro.JSON-tmLanguage
@@ -1,32 +1,32 @@
 { "name": "ChordPro",
   "scopeName": "text.chordpro",
-  "fileTypes": ["chordpro","chord","crd","chpro","cho","chopro"],
+  "fileTypes": ["chordpro","chord","crd","chpro","cho","chopro", "pro"],
   "patterns": [
-  	{ 
-  		"name":"markup.withparams.chordpro", 
+  	{
+  		"name":"markup.withparams.chordpro",
   		"match":"(?i:(\\{)(title|subtitle|comment_italic|comment|define|textfont|textsize|chordfont|chordsize|columns|page_type|t|st|ci|c|col):(.+)(\\}))",
   		"captures": {
   		    "2": { "name": "support.function.chordpro" },
           "3": { "name": "variable.parameter.chordpro"}
   		}
   	},
-    { 
-      "name":"markup.noparams.chordpro", 
+    {
+      "name":"markup.noparams.chordpro",
       "match":"(?i:(\\{)(new_song|start_of_chorus|end_of_chorus|start_of_tab|end_of_tab|no_grid|grid|new_page|new_physical_page|column_break|ns|soc|eoc|sob|eob|ng|g|npp|np|colb|col)(\\}))",
       "captures": {
           "2": { "name": "support.function.chordpro" }
       }
     },
-    { 
-      "name":"comment.chordpro", 
+    {
+      "name":"comment.chordpro",
       "match":"^#.*$"
     },
-    { 
-      "name":"keyword.chordpro", 
+    {
+      "name":"keyword.chordpro",
       "match":"(\\[)(.+?)(\\])"
     },
-    { 
-      "name":"string.chordpro", 
+    {
+      "name":"string.chordpro",
       "match":"^([a-gA-G])(\\s)*?([\\|\\-\\d\\^bs\\/])+",
       "captures": {
           "1": { "name": "keyword.chordpro" },

--- a/Syntax/ChordPro.tmLanguage
+++ b/Syntax/ChordPro.tmLanguage
@@ -10,6 +10,7 @@
 		<string>chpro</string>
 		<string>cho</string>
 		<string>chopro</string>
+		<string>pro</string>
 	</array>
 	<key>name</key>
 	<string>ChordPro</string>


### PR DESCRIPTION
Adds `.pro` to the list of default extensions.  `.pro` is a commonly used extension for ChordPro file formats, including [SongBook](https://linkesoft.com/songbook/android.html).

This PR also happens to remove some trailing whitespace.
